### PR TITLE
disable ICE mDNS candidate gathering to stop fd exhaustion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/pion/ice/v4 v4.0.10
 	github.com/pion/webrtc/v4 v4.1.6
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
@@ -22,7 +23,6 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/pion/datachannel v1.5.10 // indirect
 	github.com/pion/dtls/v3 v3.1.1 // indirect
-	github.com/pion/ice/v4 v4.0.10 // indirect
 	github.com/pion/interceptor v0.1.41 // indirect
 	github.com/pion/logging v0.2.4 // indirect
 	github.com/pion/mdns/v2 v2.0.7 // indirect

--- a/types.go
+++ b/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/pion/ice/v4"
 	"github.com/pion/webrtc/v4"
 
 	"github.com/xconnio/wampproto-go/auth"
@@ -125,6 +126,7 @@ func NewFilteredPeerConnection(iceServers []webrtc.ICEServer) (*webrtc.PeerConne
 	}
 
 	s := webrtc.SettingEngine{}
+	s.SetICEMulticastDNSMode(ice.MulticastDNSModeDisabled)
 
 	routable := outboundIPs()
 	if len(routable) > 0 {


### PR DESCRIPTION
Every `PeerConnection` created via `NewFilteredPeerConnection` used a bare `webrtc.SettingEngine{}`, so pion/ice fell back to its default `MulticastDNSModeQueryOnly` and opened a multicast UDP socket on `224.0.0.0:5353` per connection. We already exchange ICE candidates explicitly over WAMP topics (`TopicOffererOnCandidate`/`TopicAnswererOnCandidate`), so mDNS candidate resolution is never used - it was just leaking one socket per shell/file-transfer session.

Observed in production as `deskconnd` on macOS eventually failing with `too many open files` (both on `principals.json` writes and on its own LAN mDNS advertisement) after enough shell/file-transfer sessions accumulated stuck-open `224.0.0.0:5353` sockets.

Fix: explicitly disable ICE mDNS via `SetICEMulticastDNSMode(ice.MulticastDNSModeDisabled)`.

## Test plan
- `go build ./...`
- `go test ./...`
- `golangci-lint run` (0 issues)